### PR TITLE
Add private flag for setting private ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Given a CSV file with the `from` and `to` redirect values comma separated (no he
 
 *If you use a named AWS Profile, prefix the command with AWS_PROFILE=X.*
 
-Options (all required):
+Options:
 
-- `-c` CSV file with `from` and `to` values to redirect.
-- `-b` S3 Bucket to add the redirects objects to.
-
+- `-c` CSV file with `from` and `to` values to redirect. **Required**
+- `-b` S3 Bucket to add the redirects objects to. **Required**
+- `-p` Flag to set S3 Object ACL as private instead of public
 
 ### Example CSV
 
@@ -37,5 +37,5 @@ Options (all required):
 
 ### Commands
 
-- Run: `./s3-bulk-redirector.js `
+- Run: `./s3-bulk-redirector.js` with flags to test out
 - Test: `npm run test` or `npm run test:watch`

--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ Options:
 
 - Run: `./s3-bulk-redirector.js` with flags to test out
 - Test: `npm run test` or `npm run test:watch`
+
+
+## Changelog
+
+### 1.0.1
+
+Update to push new README version
+
+### 1.0.0
+
+Initial release

--- a/s3-bulk-redirector.js
+++ b/s3-bulk-redirector.js
@@ -8,19 +8,25 @@ const parser = require('./src/parser');
 
 program
   .version('1.0.0')
-  .option('-c, --csv-file <CSV_FILE>', 'CSV File to make redirects from')
+  .option('-c, --csv-file <CSV_FILE>', 'CSV File to read list of redirects')
   .option('-b, --bucket <S3_BUCKET>', 'S3 Bucket to serve redirects from')
+  .option('-p, --private', 'Use to set object ACL to private ACL instead of public')
   .parse(process.argv);
 
 if (program.csvFile === undefined || program.bucket === undefined) {
   program.outputHelp();
 } else {
+  const options = {
+    private: program.private !== undefined
+  };
+
   parser.parseCSV(program.csvFile, (redirects) => {
     redirects.forEach((redirect) => {
       s3.applyRedirect(
         program.bucket,
         formatter.formatFrom(redirect.from),
-        formatter.formatTo(redirect.to)
+        formatter.formatTo(redirect.to),
+        options
       );
     });
   });

--- a/spec/s3.spec.js
+++ b/spec/s3.spec.js
@@ -4,8 +4,38 @@ describe('s3', () => {
   describe('applyRedirect', () => {
     s3.client.putObject = jest.fn();
 
-    it ('calls put object', () => {
+    it('calls put object with no options', () => {
       s3.applyRedirect('bucket', '/from', '/to');
+
+      expect(s3.client.putObject).toHaveBeenCalledWith(
+        {
+          ACL: 'public-read',
+          Body: '',
+          Bucket: 'bucket',
+          Key: '/from',
+          WebsiteRedirectLocation: '/to'
+        },
+        s3.handleError
+      );
+    });
+
+    it('calls put object with private ACL when private option set to true', () => {
+      s3.applyRedirect('bucket', '/from', '/to', { private: true });
+
+      expect(s3.client.putObject).toHaveBeenCalledWith(
+        {
+          ACL: 'private',
+          Body: '',
+          Bucket: 'bucket',
+          Key: '/from',
+          WebsiteRedirectLocation: '/to'
+        },
+        s3.handleError
+      );
+    });
+
+    it('calls put object with public ACL when private option set to false', () => {
+      s3.applyRedirect('bucket', '/from', '/to', { private: false });
 
       expect(s3.client.putObject).toHaveBeenCalledWith(
         {

--- a/src/s3.js
+++ b/src/s3.js
@@ -1,11 +1,12 @@
 const AWS = require('aws-sdk');
 
 const PUBLIC_READ = 'public-read';
+const PRIVATE = 'private';
 const s3Client = new AWS.S3({ profile: process.env.AWS_PROFILE });
 
-function buildRedirectObject(bucket, from, to) {
+function buildRedirectObject(bucket, from, to, options) {
   return {
-    ACL: PUBLIC_READ,
+    ACL: options.private ? PRIVATE : PUBLIC_READ,
     Body: '',
     Bucket: bucket,
     Key: from,
@@ -19,8 +20,8 @@ function handleError(err, data) {
 
 exports.handleError = handleError;
 exports.client = s3Client;
-exports.applyRedirect = (bucket, from, to) => {
-  const object = buildRedirectObject(bucket, from, to);
+exports.applyRedirect = (bucket, from, to, options = {}) => {
+  const object = buildRedirectObject(bucket, from, to, options);
   s3Client.putObject(object, handleError);
   console.log("> Redirected from /" + from + " to " + to);
 }


### PR DESCRIPTION
I've been locking down my website S3 buckets to be private and be made public via referrers that are sent from Cloudfront (https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-serve-static-website/), as a result, setting public read as the ACL doesn't work and gets access denied errors. So solution is to make the S3 redirect objects private.

This adds a flag to set exactly that on bulk redirect time. 